### PR TITLE
Add release script to release fonts easily

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+release

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: python
+python:
+  - "3.5"
+install:
+  - sudo apt-get update -qq
+  - sudo apt-get install shellcheck
+script:
+  - shellcheck ./build_release
+
+before_deploy:
+  - ./build_release
+deploy:
+  provider: releases
+  api_key: "GITHUB OAUTH TOKEN"
+  file:
+    - release/SpoqaHanSans_all.zip
+    - release/SpoqaHanSans_jp_subset.zip
+    - release/SpoqaHanSans_subset.zip
+    - release/SpoqaHanSans_jp_original.zip
+    - release/SpoqaHanSans_original.zip
+  skip_cleanup: true
+  on:
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,9 @@
-language: python
-python:
-  - "3.5"
-install:
-  - sudo apt-get update -qq
-  - sudo apt-get install shellcheck
-script:
-  - shellcheck ./build_release
-
+language: bash
 before_deploy:
   - ./build_release
 deploy:
   provider: releases
-  api_key: "GITHUB OAUTH TOKEN"
+  api_key: "e82c6f1b2bfb2dd4dbf416f08bd627fd61d28f33"
   file:
     - release/SpoqaHanSans_all.zip
     - release/SpoqaHanSans_jp_subset.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,15 @@
 language: bash
 before_deploy:
-  - ./build_release
+  - "./build_release"
 deploy:
   provider: releases
-  api_key: "e82c6f1b2bfb2dd4dbf416f08bd627fd61d28f33"
+  api_key:
+    secure: SI2GRrOlxA7MRVuLhlHH2e9wmSWNHlNHp4j9BxHQ7Cv1/o86Dvww0IjcqvNC64ZyuUWXOpWMOMPLqRAnOJ5Vd5j6pDT1rdD/4sR2MjcHo2I0NUXSrMPYooxxoAVgWnllAvY8YkGOsku0nje+dbf8yi/J9PDHNmpMW89zPAp8uTlymFiAVUhYZwv5zA21TPyR7DY9vcYU3i2Oyzoq+u9++mbbKw8JlbxYGdkc5MjoMV8DxdaVnlQewSGtHatJdeh7GF/Ik7AGnv5p4xdZjio/oTXDQebcwjmYZiv+GTpn9l8wbifvK90z7iA/kf+z1jREGJ9s8pzzFRM34N/+HD4QpmpR+9RseKAl9PgzYzryO45YNstED3NuQbb3E0rhF7cNwbBRmOgwNSkcPEp9T0UR++yYu9EvLtyOQ5JzjKqaVVLW/SlTJ9iEjCQrjqoadbt8k+LgXgZhJJGaXugPkt2PM/+hGBk84YnTi6PPMjELJxJAJu5+KI6/xINwQOcAPu+mE75r//tnXdtMGcym/kE6kjtBa8Baa9JSKOG8yWya+MMY2ea9EYxanaSKBYHM6xsYY/XK7EEpwuL9T4KTXy2LipRJyvYpno3vR6sr40nSPg0pNYjyy/c7gku+thqrp2SjabriQMl4EsotbHYlM3vG51CIkHLdSn9OeS8XhLcFpXc=
   file:
     - release/SpoqaHanSans_all.zip
     - release/SpoqaHanSans_jp_subset.zip
     - release/SpoqaHanSans_subset.zip
     - release/SpoqaHanSans_jp_original.zip
     - release/SpoqaHanSans_original.zip
-  skip_cleanup: true
   on:
     tags: true

--- a/build_release
+++ b/build_release
@@ -1,8 +1,7 @@
 #!/bin/sh
+set -e
 
-release_tag="$(git tag | tail -n 1)";
-origin="git@github.com:spoqa/spoqa-han-sans.git";
-master="master"
+release_tag="${TRAVIS_TAG:-"$(git tag | tail -n 1)"}";
 project_root="$(pwd)";
 release_base_dir="$project_root/release";
 release_all_name="SpoqaHanSans_all";
@@ -22,7 +21,7 @@ build_zip()
   cp -r "$release_dir" "$all_dir";
   cp LICENSE "$release_dir/";
 
-  cd "$release_base_dir" || exit;
+  cd "$release_base_dir";
   zip "$release_dir.zip" -r "$release_dirname" >> /dev/null;
   cd ..
   rm -rf "$release_dir";
@@ -31,11 +30,10 @@ build_zip()
 echo "Release $release_tag";
 echo "~~~~~~~~~~~~~~~";
 
+echo "${TRAVIS_REPO_SLUG:-"origin"}/${TRAVIS_BRANCH:-"master"}";
+
 # git log from pre-released version to current version
 # git log "$(git tag | tail -n 2 | head -n 1)"..."$release_tag" --pretty="format:%an <%ae> %s" --no-merges
-
-echo "# Git tag"
-echo "host: $origin, branch: $master";
 
 echo "# Compress fonts...";
 
@@ -52,7 +50,7 @@ build_zip "jp_subset" \
           "Subset/SpoqaHanSans_JP";
 
 echo "* release $release_all_name";
-cd "$release_base_dir" || exit;
+cd "$release_base_dir";
 zip "$release_all_name.zip" -r "$release_all_name" >> /dev/null;
 rm -rf "$release_all_name";
 cd ..

--- a/build_release
+++ b/build_release
@@ -22,7 +22,7 @@ build_zip()
   cp LICENSE "$release_dir/";
 
   cd "$release_base_dir";
-  zip "$release_dir.zip" -r "$release_dirname" >> /dev/null;
+  zip "$release_dir.zip" -r "$release_dirname";
   cd ..
   rm -rf "$release_dir";
 }
@@ -51,7 +51,7 @@ build_zip "jp_subset" \
 
 echo "* release $release_all_name";
 cd "$release_base_dir";
-zip "$release_all_name.zip" -r "$release_all_name" >> /dev/null;
+zip "$release_all_name.zip" -r "$release_all_name";
 rm -rf "$release_all_name";
 cd ..
 

--- a/build_release
+++ b/build_release
@@ -1,48 +1,20 @@
 #!/bin/sh
 
-#shellcheck build_release
-
-git_tag="$(git tag | tail -n 1)";
-
-if [ "$1" = "" ];
-then
-  release_tag="$(git tag | tail -n 1)";
-else
-  release_tag="$1";
-fi
-
-echo "Release $release_tag";
-echo "~~~~~~~~~~~~~~~";
-
-# git log from pre-released version to current version
-# git log "$(git tag | tail -n 2 | head -n 1)"..."$git_tag" --pretty="format:%an <%ae> %s" --no-merges
-
-echo "# Git tag"
+release_tag="$(git tag | tail -n 1)";
 origin="git@github.com:spoqa/spoqa-han-sans.git";
 master="master"
-echo "host: $origin, branch: $master";
-if [ "$git_tag" != "$release_tag" ] && [ ! -z "$(git tag | grep "$release_tag")" ];
-then
-  git checkout $master;
-  git pull $origin $master;
-
-  git tag "$release_tag";
-
-  git push $origin "$release_tag";
-fi
-
 project_root="$(pwd)";
 release_base_dir="$project_root/release";
-mkdir -p "$release_base_dir";
-
-release_all_name="SpoqaHanSans_all_$release_tag";
+release_all_name="SpoqaHanSans_all";
 all_dir="$release_base_dir/$release_all_name";
+
+mkdir -p "$release_base_dir";
 mkdir -p "$all_dir";
 cp LICENSE "$all_dir";
 
 build_zip()
 {
-  release_dirname="SpoqaHanSans_$1_$release_tag";
+  release_dirname="SpoqaHanSans_$1";
   release_dir="$release_base_dir/$release_dirname";
   echo "* release $release_dirname";
   mkdir -p "$release_dir";
@@ -50,11 +22,20 @@ build_zip()
   cp -r "$release_dir" "$all_dir";
   cp LICENSE "$release_dir/";
 
-  cd "$release_base_dir";
+  cd "$release_base_dir" || exit;
   zip "$release_dir.zip" -r "$release_dirname" >> /dev/null;
   cd ..
   rm -rf "$release_dir";
 }
+
+echo "Release $release_tag";
+echo "~~~~~~~~~~~~~~~";
+
+# git log from pre-released version to current version
+# git log "$(git tag | tail -n 2 | head -n 1)"..."$release_tag" --pretty="format:%an <%ae> %s" --no-merges
+
+echo "# Git tag"
+echo "host: $origin, branch: $master";
 
 echo "# Compress fonts...";
 
@@ -71,9 +52,9 @@ build_zip "jp_subset" \
           "Subset/SpoqaHanSans_JP";
 
 echo "* release $release_all_name";
-cd "$release_base_dir";
+cd "$release_base_dir" || exit;
 zip "$release_all_name.zip" -r "$release_all_name" >> /dev/null;
 rm -rf "$release_all_name";
-cd ..;
+cd ..
 
 echo "release done.";

--- a/build_release
+++ b/build_release
@@ -1,0 +1,79 @@
+#!/bin/sh
+
+#shellcheck build_release
+
+git_tag="$(git tag | tail -n 1)";
+
+if [ "$1" = "" ];
+then
+  release_tag="$(git tag | tail -n 1)";
+else
+  release_tag="$1";
+fi
+
+echo "Release $release_tag";
+echo "~~~~~~~~~~~~~~~";
+
+# git log from pre-released version to current version
+# git log "$(git tag | tail -n 2 | head -n 1)"..."$git_tag" --pretty="format:%an <%ae> %s" --no-merges
+
+echo "# Git tag"
+origin="git@github.com:spoqa/spoqa-han-sans.git";
+master="master"
+echo "host: $origin, branch: $master";
+if [ "$git_tag" != "$release_tag" ] && [ ! -z "$(git tag | grep "$release_tag")" ];
+then
+  git checkout $master;
+  git pull $origin $master;
+
+  git tag "$release_tag";
+
+  git push $origin "$release_tag";
+fi
+
+project_root="$(pwd)";
+release_base_dir="$project_root/release";
+mkdir -p "$release_base_dir";
+
+release_all_name="SpoqaHanSans_all_$release_tag";
+all_dir="$release_base_dir/$release_all_name";
+mkdir -p "$all_dir";
+cp LICENSE "$all_dir";
+
+build_zip()
+{
+  release_dirname="SpoqaHanSans_$1_$release_tag";
+  release_dir="$release_base_dir/$release_dirname";
+  echo "* release $release_dirname";
+  mkdir -p "$release_dir";
+  cp -r "$project_root/$2/"* "$release_dir/";
+  cp -r "$release_dir" "$all_dir";
+  cp LICENSE "$release_dir/";
+
+  cd "$release_base_dir";
+  zip "$release_dir.zip" -r "$release_dirname" >> /dev/null;
+  cd ..
+  rm -rf "$release_dir";
+}
+
+echo "# Compress fonts...";
+
+build_zip "original" \
+          "Original/SpoqaHanSans";
+
+build_zip "jp_original" \
+          "Original/SpoqaHanSans_JP";
+
+build_zip "subset" \
+          "Subset/SpoqaHanSans";
+
+build_zip "jp_subset" \
+          "Subset/SpoqaHanSans_JP";
+
+echo "* release $release_all_name";
+cd "$release_base_dir";
+zip "$release_all_name.zip" -r "$release_all_name" >> /dev/null;
+rm -rf "$release_all_name";
+cd ..;
+
+echo "release done.";


### PR DESCRIPTION
bash를 통해서 release에 올리는 zip 파일들을 만듭니다. 실행방법은 터미널에서

    $ ./build_release 1.0.0

같이 실행하면됩니다. 내부에선 다음과 같은 일을합니다.

- 현재 버전에 git tag를 답니다.
- Original/Subset 모든 버전에대해서 라이센스 파일을 추가하여 zip파일을생성합니다.
- 라이센스를 추가하여 모든 폰트들이 모여있는 zip 파일을 만듭니다.
