### PR TITLE
모바일 뷰에서 `ㅇ스포카 한 산스 ㅇ본고딕` 숨기기

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: ruby
+rvm:
+- 2.1.1
 before_install:
-- gem install -N jekyll
+- gem install -N jekyll:2.4.0
 script:
 - ./lint.sh

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -40,6 +40,13 @@
       ga('create', 'UA-61954097-5', 'auto');
       ga('send', 'pageview');
     </script>
+    <script type="text/javascript">
+      if ("ontouchstart" in document.documentElement) {
+          document.documentElement.className += " touch";
+      } else {
+          document.documentElement.className += " no-touch";
+      }
+    </script>
   </head>
   <body>
     <!-- Load Facebook SDK for JavaScript -->

--- a/css/style.scss
+++ b/css/style.scss
@@ -223,6 +223,13 @@ section h3 {
   margin-top: 60px;
   margin-bottom: 40px;
   text-align: right;
+  
+  @media only screen and (max-width: 650px) {
+    margin-top: 20px;
+  }
+  @media only screen and (max-width: 400px) {
+    margin-top: 10px;
+  }
 }
 .color-circle-wrap {
   display: inline-block;

--- a/css/style.scss
+++ b/css/style.scss
@@ -229,6 +229,13 @@ section h3 {
   margin-right: 30px;
   float: right;
 
+  @media only screen and (max-width: 650px) {
+    display: none;
+  }
+  @media only screen and (max-width: 400px) {
+    display: none;
+  }
+
   .color-circle {
     display: inline-block;
     height: 16px;

--- a/css/style.scss
+++ b/css/style.scss
@@ -223,25 +223,11 @@ section h3 {
   margin-top: 60px;
   margin-bottom: 40px;
   text-align: right;
-  
-  @media only screen and (max-width: 650px) {
-    margin-top: 20px;
-  }
-  @media only screen and (max-width: 400px) {
-    margin-top: 10px;
-  }
 }
 .color-circle-wrap {
   display: inline-block;
   margin-right: 30px;
   float: right;
-
-  @media only screen and (max-width: 650px) {
-    display: none;
-  }
-  @media only screen and (max-width: 400px) {
-    display: none;
-  }
 
   .color-circle {
     display: inline-block;

--- a/css/style.scss
+++ b/css/style.scss
@@ -249,6 +249,14 @@ section h3 {
   }
 }
 
+.touch {
+  .group-color-circle {
+    margin-top: 10px;
+  }
+  .color-circle-wrap {
+    display: none;
+  }
+}
 
 .section-glyphs {
   padding-top: 0;


### PR DESCRIPTION
**ㅇ스포카 한 산스 ㅇ본고딕** 이 부분이 마우스 오버 가능한 영역이 아닌데도 마우스 오버 가능하게 보여지는 상태를 고칩니다. 리뷰 및 QA는 @yeun 님께 부탁드립니다! 