### PR TITLE
이메일 관련 개선

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,4 +8,4 @@ kramdown:
   hard_wrap: false
 
 email:
-  address: visual-design@spoqa.com
+  address: visual-design+spoqahansans@spoqa.com

--- a/_config.yml
+++ b/_config.yml
@@ -7,3 +7,5 @@ kramdown:
   input: GFM
   hard_wrap: false
 
+email:
+  address: visual-design@spoqa.com

--- a/_config.yml
+++ b/_config.yml
@@ -9,3 +9,4 @@ kramdown:
 
 email:
   address: visual-design+spoqahansans@spoqa.com
+  body_preset: '혹시 문의하려던 내용이 상업적 이용에 관한 질문인가요? 스포카 한 산스는 오픈 폰트 라이선스로 상업적으로도 자유롭게 사용, 수정 및 재배포할 수 있습니다.'

--- a/index.html
+++ b/index.html
@@ -399,7 +399,7 @@ layout: default
           <div class="col-sm-4 col-xs-12">
             <h3>문의 사항을 보내주세요. </h3>
             <div>
-              <a href="mailto:{{ site.email.address }}">
+              <a href="mailto:{{ site.email.address }}?body={{ site.email.body_preset|url_encode|replace:'+','%20'|escape }}">
                 스포카 디자인팀에 메일 보내기 &gt;
               </a> 
             </div>

--- a/index.html
+++ b/index.html
@@ -399,7 +399,7 @@ layout: default
           <div class="col-sm-4 col-xs-12">
             <h3>문의 사항을 보내주세요. </h3>
             <div>
-              <a href="mailto:visual-design@spoqa.com">
+              <a href="mailto:{{ site.email.address }}">
                 스포카 디자인팀에 메일 보내기 &gt;
               </a> 
             </div>


### PR DESCRIPTION
3가지 개선을 했습니다.

첫째로는 이메일 주소 뒤에 `+spoqahansans`를 붙여서, 이메일 받을 때 필터를 통해 자동으로 레이블링을 한다거나 할 수 있도록 만들었습니다. 보통 이를 [plus addressing][1]이라고 합니다.

둘째로는 반복되는 상업적 이용 권리에 대한 문의를 조금이라도 줄이기 위해, 이메일 링크에 미리 채워진 내용이 뜨도록 만들었습니다. <q>스포카 디자인팀에 메일 보내기 &gt;</q> 버튼을 누르면 아래와 같이 자주 질문되는 내용에 대한 답변이 미리 채워진 채로 메일 작성 양식이 뜨게 됩니다:

![screen shot 2016-04-07 at 3 00 31 pm](https://cloud.githubusercontent.com/assets/12431/14342130/7c2881fa-fcd2-11e5-9b27-4ea70387080a.png)
 
셋째로는 이런 저런 병경을 하다보니 이메일 링크에 코드가 너무 복잡해져서, 관련된 내용을 _config.yml 설정 파일로 분리한 것입니다.

[1]: https://gmail.googleblog.com/2008/03/2-hidden-ways-to-get-more-from-your.html