### PR TITLE
Improve @font-face rule

### DIFF
--- a/css/SpoqaHanSans-jp.css
+++ b/css/SpoqaHanSans-jp.css
@@ -24,29 +24,35 @@
 @font-face {
     font-family: 'Spoqa Han Sans JP';
     font-weight: 700;
-    src: local('SpoqaHanSansJP-Bold'), local('SpoqaHanSansJP-Bold'),
-    url('../Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset(webfont%20inclued)/SpoqaHanSansJP-Bold/SpoqaHanSansJP-Bold.eot') format('eot'),
-    url('../Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset(webfont%20inclued)/SpoqaHanSansJP-Bold/SpoqaHanSansJP-Bold.svg') format('svg'),
+    src: url('../Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset(webfont%20inclued)/SpoqaHanSansJP-Bold/SpoqaHanSansJP-Bold.eot');
+    src: local('SpoqaHanSansJP-Bold'),
+    url('../Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset(webfont%20inclued)/SpoqaHanSansJP-Bold/SpoqaHanSansJP-Bold.eot?#iefix') format('embedded-opentype'),
+    url('../Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset(webfont%20inclued)/SpoqaHanSansJP-Bold/SpoqaHanSansJP-Bold.woff2') format('woff2'),
+    url('../Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset(webfont%20inclued)/SpoqaHanSansJP-Bold/SpoqaHanSansJP-Bold.woff') format('woff'),
     url('../Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset(webfont%20inclued)/SpoqaHanSansJP-Bold/SpoqaHanSansJP-Bold.ttf') format('truetype'),
-    url('../Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset(webfont%20inclued)/SpoqaHanSansJP-Bold/SpoqaHanSansJP-Bold.woff') format('woff');
+    url('../Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset(webfont%20inclued)/SpoqaHanSansJP-Bold/SpoqaHanSansJP-Bold.svg#SpoqaHanSansJP') format('svg');
 }
 
 @font-face {
     font-family: 'Spoqa Han Sans JP';
     font-weight: 400;
-    src: local('SpoqaHanSansJP-Regular'), local('SpoqaHanSansJP-Regular'),
-    url('../Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset(webfont%20inclued)/SpoqaHanSansJP-Regular/SpoqaHanSansJP-Regular.eot') format('eot'),
-    url('../Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset(webfont%20inclued)/SpoqaHanSansJP-Regular/SpoqaHanSansJP-Regular.svg') format('svg'),
+    src: url('../Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset(webfont%20inclued)/SpoqaHanSansJP-Regular/SpoqaHanSansJP-Regular.eot');
+    src: local('SpoqaHanSansJP-Regular'),
+    url('../Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset(webfont%20inclued)/SpoqaHanSansJP-Regular/SpoqaHanSansJP-Regular.eot?#iefix') format('embedded-opentype'),
+    url('../Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset(webfont%20inclued)/SpoqaHanSansJP-Regular/SpoqaHanSansJP-Regular.woff2') format('woff2'),
+    url('../Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset(webfont%20inclued)/SpoqaHanSansJP-Regular/SpoqaHanSansJP-Regular.woff') format('woff'),
     url('../Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset(webfont%20inclued)/SpoqaHanSansJP-Regular/SpoqaHanSansJP-Regular.ttf') format('truetype'),
-    url('../Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset(webfont%20inclued)/SpoqaHanSansJP-Regular/SpoqaHanSansJP-Regular.woff') format('woff');
+    url('../Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset(webfont%20inclued)/SpoqaHanSansJP-Regular/SpoqaHanSansJP-Regular.svg#SpoqaHanSansJP') format('svg');
 }
 
 @font-face {
     font-family: 'Spoqa Han Sans JP';
     font-weight: 200;
-    src: local('SpoqaHanSansJP-Thin'), local('SpoqaHanSansJP-Thin'),
-    url('../Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset(webfont%20inclued)/SpoqaHanSansJP-Thin/SpoqaHanSansJP-Thin.eot') format('eot'),
-    url('../Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset(webfont%20inclued)/SpoqaHanSansJP-Thin/SpoqaHanSansJP-Thin.svg') format('svg'),
+    src: url('../Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset(webfont%20inclued)/SpoqaHanSansJP-Thin/SpoqaHanSansJP-Thin.eot');
+    src: local('SpoqaHanSansJP-Thin'),
+    url('../Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset(webfont%20inclued)/SpoqaHanSansJP-Thin/SpoqaHanSansJP-Thin.eot?#iefix') format('embedded-opentype'),
+    url('../Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset(webfont%20inclued)/SpoqaHanSansJP-Thin/SpoqaHanSansJP-Thin.woff2') format('woff2'),
+    url('../Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset(webfont%20inclued)/SpoqaHanSansJP-Thin/SpoqaHanSansJP-Thin.woff') format('woff'),
     url('../Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset(webfont%20inclued)/SpoqaHanSansJP-Thin/SpoqaHanSansJP-Thin.ttf') format('truetype'),
-    url('../Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset(webfont%20inclued)/SpoqaHanSansJP-Thin/SpoqaHanSansJP-Thin.woff') format('woff');
+    url('../Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset(webfont%20inclued)/SpoqaHanSansJP-Thin/SpoqaHanSansJP-Thin.svg#SpoqaHanSansJP') format('svg');
 }

--- a/css/SpoqaHanSans-kr.css
+++ b/css/SpoqaHanSans-kr.css
@@ -24,29 +24,35 @@
 @font-face {
     font-family: 'Spoqa Han Sans';
     font-weight: 700;
-    src: local('SpoqaHanSans-Bold'), local('SpoqaHanSans-Bold'),
-    url('../Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset(webfont%20inclued)/SpoqaHanSans-Bold/SpoqaHanSans-Bold.eot') format('eot'),
-    url('../Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset(webfont%20inclued)/SpoqaHanSans-Bold/SpoqaHanSans-Bold.svg') format('svg'),
+    src: url('../Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset(webfont%20inclued)/SpoqaHanSans-Bold/SpoqaHanSans-Bold.eot');
+    src: local('SpoqaHanSans-Bold'),
+    url('../Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset(webfont%20inclued)/SpoqaHanSans-Bold/SpoqaHanSans-Bold.eot?#iefix') format('embedded-opentype'),
+    url('../Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset(webfont%20inclued)/SpoqaHanSans-Bold/SpoqaHanSans-Bold.woff2') format('woff2'),
+    url('../Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset(webfont%20inclued)/SpoqaHanSans-Bold/SpoqaHanSans-Bold.woff') format('woff'),
     url('../Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset(webfont%20inclued)/SpoqaHanSans-Bold/SpoqaHanSans-Bold.ttf') format('truetype'),
-    url('../Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset(webfont%20inclued)/SpoqaHanSans-Bold/SpoqaHanSans-Bold.woff') format('woff');
+    url('../Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset(webfont%20inclued)/SpoqaHanSans-Bold/SpoqaHanSans-Bold.svg#SpoqaHanSans') format('svg');
 }
 
 @font-face {
     font-family: 'Spoqa Han Sans';
     font-weight: 400;
-    src: local('SpoqaHanSans-Regular'), local('SpoqaHanSans-Regular'),
-    url('../Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset(webfont%20inclued)/SpoqaHanSans-Regular/SpoqaHanSans-Regular.eot') format('eot'),
-    url('../Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset(webfont%20inclued)/SpoqaHanSans-Regular/SpoqaHanSans-Regular.svg') format('svg'),
+    src: url('../Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset(webfont%20inclued)/SpoqaHanSans-Regular/SpoqaHanSans-Regular.eot');
+    src: local('SpoqaHanSans-Regular'),
+    url('../Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset(webfont%20inclued)/SpoqaHanSans-Regular/SpoqaHanSans-Regular.eot?#iefix') format('embedded-opentype'),
+    url('../Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset(webfont%20inclued)/SpoqaHanSans-Regular/SpoqaHanSans-Regular.woff2') format('woff2'),
+    url('../Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset(webfont%20inclued)/SpoqaHanSans-Regular/SpoqaHanSans-Regular.woff') format('woff'),
     url('../Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset(webfont%20inclued)/SpoqaHanSans-Regular/SpoqaHanSans-Regular.ttf') format('truetype'),
-    url('../Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset(webfont%20inclued)/SpoqaHanSans-Regular/SpoqaHanSans-Regular.woff') format('woff');
+    url('../Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset(webfont%20inclued)/SpoqaHanSans-Regular/SpoqaHanSans-Regular.svg#SpoqaHanSans') format('svg');
 }
 
 @font-face {
     font-family: 'Spoqa Han Sans';
     font-weight: 200;
-    src: local('SpoqaHanSans-Thin'), local('SpoqaHanSans-Thin'),
-    url('../Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset(webfont%20inclued)/SpoqaHanSans-Thin/SpoqaHanSans-Thin.eot') format('eot'),
-    url('../Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset(webfont%20inclued)/SpoqaHanSans-Thin/SpoqaHanSans-Thin.svg') format('svg'),
+    src: url('../Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset(webfont%20inclued)/SpoqaHanSans-Thin/SpoqaHanSans-Thin.eot');
+    src: local('SpoqaHanSans-Thin'),
+    url('../Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset(webfont%20inclued)/SpoqaHanSans-Thin/SpoqaHanSans-Thin.eot?#iefix') format('embedded-opentype'),
+    url('../Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset(webfont%20inclued)/SpoqaHanSans-Thin/SpoqaHanSans-Thin.woff2') format('woff2'),
+    url('../Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset(webfont%20inclued)/SpoqaHanSans-Thin/SpoqaHanSans-Thin.woff') format('woff'),
     url('../Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset(webfont%20inclued)/SpoqaHanSans-Thin/SpoqaHanSans-Thin.ttf') format('truetype'),
-    url('../Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset(webfont%20inclued)/SpoqaHanSans-Thin/SpoqaHanSans-Thin.woff') format('woff');
+    url('../Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset(webfont%20inclued)/SpoqaHanSans-Thin/SpoqaHanSans-Thin.svg#SpoqaHanSans') format('svg');
 }

--- a/less/spoqa-han-sans-jp.less
+++ b/less/spoqa-han-sans-jp.less
@@ -3,29 +3,35 @@
 @font-face {
     font-family: 'Spoqa Han Sans JP';
     font-weight: 700;
-    src: local('SpoqaHanSansJP-Bold'), local('SpoqaHanSansJP-Bold'),
-    url('@{spoqa-han-sans-path}/SpoqaHanSansJP-Bold/SpoqaHanSansJP-Bold.eot') format('eot'),
-    url('@{spoqa-han-sans-path}/SpoqaHanSansJP-Bold/SpoqaHanSansJP-Bold.svg') format('svg'),
+    src: url('@{spoqa-han-sans-path}/SpoqaHanSansJP-Bold/SpoqaHanSansJP-Bold.eot');
+    src: local('SpoqaHanSansJP-Bold'),
+    url('@{spoqa-han-sans-path}/SpoqaHanSansJP-Bold/SpoqaHanSansJP-Bold.eot?#iefix') format('embedded-opentype'),
+    url('@{spoqa-han-sans-path}/SpoqaHanSansJP-Bold/SpoqaHanSansJP-Bold.woff2') format('woff2'),
+    url('@{spoqa-han-sans-path}/SpoqaHanSansJP-Bold/SpoqaHanSansJP-Bold.woff') format('woff'),
     url('@{spoqa-han-sans-path}/SpoqaHanSansJP-Bold/SpoqaHanSansJP-Bold.ttf') format('truetype'),
-    url('@{spoqa-han-sans-path}/SpoqaHanSansJP-Bold/SpoqaHanSansJP-Bold.woff') format('woff');
+    url('@{spoqa-han-sans-path}/SpoqaHanSansJP-Bold/SpoqaHanSansJP-Bold.svg#SpoqaHanSansJP') format('svg');
 }
 
 @font-face {
     font-family: 'Spoqa Han Sans JP';
     font-weight: 400;
-    src: local('SpoqaHanSansJP-Regular'), local('SpoqaHanSansJP-Regular'),
-    url('@{spoqa-han-sans-path}/SpoqaHanSansJP-Regular/SpoqaHanSansJP-Regular.eot') format('eot'),
-    url('@{spoqa-han-sans-path}/SpoqaHanSansJP-Regular/SpoqaHanSansJP-Regular.svg') format('svg'),
+    src: url('@{spoqa-han-sans-path}/SpoqaHanSansJP-Regular/SpoqaHanSansJP-Regular.eot');
+    src: local('SpoqaHanSansJP-Regular'),
+    url('@{spoqa-han-sans-path}/SpoqaHanSansJP-Regular/SpoqaHanSansJP-Regular.eot?#iefix') format('embedded-opentype'),
+    url('@{spoqa-han-sans-path}/SpoqaHanSansJP-Regular/SpoqaHanSansJP-Regular.woff2') format('woff2'),
+    url('@{spoqa-han-sans-path}/SpoqaHanSansJP-Regular/SpoqaHanSansJP-Regular.woff') format('woff'),
     url('@{spoqa-han-sans-path}/SpoqaHanSansJP-Regular/SpoqaHanSansJP-Regular.ttf') format('truetype'),
-    url('@{spoqa-han-sans-path}/SpoqaHanSansJP-Regular/SpoqaHanSansJP-Regular.woff') format('woff');
+    url('@{spoqa-han-sans-path}/SpoqaHanSansJP-Regular/SpoqaHanSansJP-Regular.svg#SpoqaHanSansJP') format('svg');
 }
 
 @font-face {
     font-family: 'Spoqa Han Sans JP';
     font-weight: 200;
-    src: local('SpoqaHanSansJP-Thin'), local('SpoqaHanSansJP-Thin'),
-    url('@{spoqa-han-sans-path}/SpoqaHanSansJP-Thin/SpoqaHanSansJP-Thin.eot') format('eot'),
-    url('@{spoqa-han-sans-path}/SpoqaHanSansJP-Thin/SpoqaHanSansJP-Thin.svg') format('svg'),
+    src: url('@{spoqa-han-sans-path}/SpoqaHanSansJP-Thin/SpoqaHanSansJP-Thin.eot');
+    src: local('SpoqaHanSansJP-Thin'),
+    url('@{spoqa-han-sans-path}/SpoqaHanSansJP-Thin/SpoqaHanSansJP-Thin.eot?#iefix') format('embedded-opentype'),
+    url('@{spoqa-han-sans-path}/SpoqaHanSansJP-Thin/SpoqaHanSansJP-Thin.woff2') format('woff2'),
+    url('@{spoqa-han-sans-path}/SpoqaHanSansJP-Thin/SpoqaHanSansJP-Thin.woff') format('woff'),
     url('@{spoqa-han-sans-path}/SpoqaHanSansJP-Thin/SpoqaHanSansJP-Thin.ttf') format('truetype'),
-    url('@{spoqa-han-sans-path}/SpoqaHanSansJP-Thin/SpoqaHanSansJP-Thin.woff') format('woff');
+    url('@{spoqa-han-sans-path}/SpoqaHanSansJP-Thin/SpoqaHanSansJP-Thin.svg#SpoqaHanSansJP') format('svg');
 }

--- a/less/spoqa-han-sans-kr.less
+++ b/less/spoqa-han-sans-kr.less
@@ -3,29 +3,35 @@
 @font-face {
     font-family: 'Spoqa Han Sans';
     font-weight: 700;
-    src: local('SpoqaHanSans-Bold'), local('SpoqaHanSans-Bold'),
-    url('@{spoqa-han-sans-path}/SpoqaHanSans-Bold/SpoqaHanSans-Bold.eot') format('eot'),
-    url('@{spoqa-han-sans-path}/SpoqaHanSans-Bold/SpoqaHanSans-Bold.svg') format('svg'),
+    src: url('@{spoqa-han-sans-path}/SpoqaHanSans-Bold/SpoqaHanSans-Bold.eot');
+    src: local('SpoqaHanSans-Bold'),
+    url('@{spoqa-han-sans-path}/SpoqaHanSans-Bold/SpoqaHanSans-Bold.eot?#iefix') format('embedded-opentype'),
+    url('@{spoqa-han-sans-path}/SpoqaHanSans-Bold/SpoqaHanSans-Bold.woff2') format('woff2'),
+    url('@{spoqa-han-sans-path}/SpoqaHanSans-Bold/SpoqaHanSans-Bold.woff') format('woff'),
     url('@{spoqa-han-sans-path}/SpoqaHanSans-Bold/SpoqaHanSans-Bold.ttf') format('truetype'),
-    url('@{spoqa-han-sans-path}/SpoqaHanSans-Bold/SpoqaHanSans-Bold.woff') format('woff');
+    url('@{spoqa-han-sans-path}/SpoqaHanSans-Bold/SpoqaHanSans-Bold.svg#SpoqaHanSans') format('svg');
 }
 
 @font-face {
     font-family: 'Spoqa Han Sans';
     font-weight: 400;
-    src: local('SpoqaHanSans-Regular'), local('SpoqaHanSans-Regular'),
-    url('@{spoqa-han-sans-path}/SpoqaHanSans-Regular/SpoqaHanSans-Regular.eot') format('eot'),
-    url('@{spoqa-han-sans-path}/SpoqaHanSans-Regular/SpoqaHanSans-Regular.svg') format('svg'),
+    src: url('@{spoqa-han-sans-path}/SpoqaHanSans-Regular/SpoqaHanSans-Regular.eot');
+    src: local('SpoqaHanSans-Regular'),
+    url('@{spoqa-han-sans-path}/SpoqaHanSans-Regular/SpoqaHanSans-Regular.eot?#iefix') format('embedded-opentype'),
+    url('@{spoqa-han-sans-path}/SpoqaHanSans-Regular/SpoqaHanSans-Regular.woff2') format('woff2'),
+    url('@{spoqa-han-sans-path}/SpoqaHanSans-Regular/SpoqaHanSans-Regular.woff') format('woff'),
     url('@{spoqa-han-sans-path}/SpoqaHanSans-Regular/SpoqaHanSans-Regular.ttf') format('truetype'),
-    url('@{spoqa-han-sans-path}/SpoqaHanSans-Regular/SpoqaHanSans-Regular.woff') format('woff');
+    url('@{spoqa-han-sans-path}/SpoqaHanSans-Regular/SpoqaHanSans-Regular.svg#SpoqaHanSans') format('svg');
 }
 
 @font-face {
     font-family: 'Spoqa Han Sans';
     font-weight: 200;
-    src: local('SpoqaHanSans-Thin'), local('SpoqaHanSans-Thin'),
-    url('@{spoqa-han-sans-path}/SpoqaHanSans-Thin/SpoqaHanSans-Thin.eot') format('eot'),
-    url('@{spoqa-han-sans-path}/SpoqaHanSans-Thin/SpoqaHanSans-Thin.svg') format('svg'),
+    src: url('@{spoqa-han-sans-path}/SpoqaHanSans-Thin/SpoqaHanSans-Thin.eot');
+    src: local('SpoqaHanSans-Thin'),
+    url('@{spoqa-han-sans-path}/SpoqaHanSans-Thin/SpoqaHanSans-Thin.eot?#iefix') format('embedded-opentype'),
+    url('@{spoqa-han-sans-path}/SpoqaHanSans-Thin/SpoqaHanSans-Thin.woff2') format('woff2'),
+    url('@{spoqa-han-sans-path}/SpoqaHanSans-Thin/SpoqaHanSans-Thin.woff') format('woff'),
     url('@{spoqa-han-sans-path}/SpoqaHanSans-Thin/SpoqaHanSans-Thin.ttf') format('truetype'),
-    url('@{spoqa-han-sans-path}/SpoqaHanSans-Thin/SpoqaHanSans-Thin.woff') format('woff');
+    url('@{spoqa-han-sans-path}/SpoqaHanSans-Thin/SpoqaHanSans-Thin.svg#SpoqaHanSans') format('svg');
 }

--- a/scss/spoqa-han-sans-jp.scss
+++ b/scss/spoqa-han-sans-jp.scss
@@ -3,29 +3,35 @@ $spoqa-han-sans-path: "../Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset(
 @font-face {
     font-family: 'Spoqa Han Sans JP';
     font-weight: 700;
-    src: local('SpoqaHanSansJP-Bold'), local('SpoqaHanSansJP-Bold'),
-    url(#{$spoqa-han-sans-path}/SpoqaHanSansJP-Bold/SpoqaHanSansJP-Bold.eot) format('eot'),
-    url(#{$spoqa-han-sans-path}/SpoqaHanSansJP-Bold/SpoqaHanSansJP-Bold.svg) format('svg'),
-    url(#{$spoqa-han-sans-path}/SpoqaHanSansJP-Bold/SpoqaHanSansJP-Bold.ttf) format('truetype'),
-    url(#{$spoqa-han-sans-path}/SpoqaHanSansJP-Bold/SpoqaHanSansJP-Bold.woff) format('woff');
+    src: url('#{$spoqa-han-sans-path}/SpoqaHanSansJP-Bold/SpoqaHanSansJP-Bold.eot');
+    src: local('SpoqaHanSansJP-Bold'),
+    url('#{$spoqa-han-sans-path}/SpoqaHanSansJP-Bold/SpoqaHanSansJP-Bold.eot?#iefix') format('embedded-opentype'),
+    url('#{$spoqa-han-sans-path}/SpoqaHanSansJP-Bold/SpoqaHanSansJP-Bold.woff2') format('woff2'),
+    url('#{$spoqa-han-sans-path}/SpoqaHanSansJP-Bold/SpoqaHanSansJP-Bold.woff') format('woff'),
+    url('#{$spoqa-han-sans-path}/SpoqaHanSansJP-Bold/SpoqaHanSansJP-Bold.ttf') format('truetype'),
+    url('#{$spoqa-han-sans-path}/SpoqaHanSansJP-Bold/SpoqaHanSansJP-Bold.svg#SpoqaHanSansJP') format('svg');
 }
 
 @font-face {
     font-family: 'Spoqa Han Sans JP';
     font-weight: 400;
-    src: local('SpoqaHanSansJP-Regular'), local('SpoqaHanSansJP-Regular'),
-    url(#{$spoqa-han-sans-path}/SpoqaHanSansJP-Regular/SpoqaHanSansJP-Regular.eot) format('eot'),
-    url(#{$spoqa-han-sans-path}/SpoqaHanSansJP-Regular/SpoqaHanSansJP-Regular.svg) format('svg'),
-    url(#{$spoqa-han-sans-path}/SpoqaHanSansJP-Regular/SpoqaHanSansJP-Regular.ttf) format('truetype'),
-    url(#{$spoqa-han-sans-path}/SpoqaHanSansJP-Regular/SpoqaHanSansJP-Regular.woff) format('woff');
+    src: url('#{$spoqa-han-sans-path}/SpoqaHanSansJP-Regular/SpoqaHanSansJP-Regular.eot');
+    src: local('SpoqaHanSansJP-Regular'),
+    url('#{$spoqa-han-sans-path}/SpoqaHanSansJP-Regular/SpoqaHanSansJP-Regular.eot?#iefix') format('embedded-opentype'),
+    url('#{$spoqa-han-sans-path}/SpoqaHanSansJP-Regular/SpoqaHanSansJP-Regular.woff2') format('woff2'),
+    url('#{$spoqa-han-sans-path}/SpoqaHanSansJP-Regular/SpoqaHanSansJP-Regular.woff') format('woff'),
+    url('#{$spoqa-han-sans-path}/SpoqaHanSansJP-Regular/SpoqaHanSansJP-Regular.ttf') format('truetype'),
+    url('#{$spoqa-han-sans-path}/SpoqaHanSansJP-Regular/SpoqaHanSansJP-Regular.svg#SpoqaHanSansJP') format('svg');
 }
 
 @font-face {
     font-family: 'Spoqa Han Sans JP';
     font-weight: 200;
-    src: local('SpoqaHanSansJP-Thin'), local('SpoqaHanSansJP-Thin'),
-    url(#{$spoqa-han-sans-path}/SpoqaHanSansJP-Thin/SpoqaHanSansJP-Thin.eot) format('eot'),
-    url(#{$spoqa-han-sans-path}/SpoqaHanSansJP-Thin/SpoqaHanSansJP-Thin.svg) format('svg'),
-    url(#{$spoqa-han-sans-path}/SpoqaHanSansJP-Thin/SpoqaHanSansJP-Thin.ttf) format('truetype'),
-    url(#{$spoqa-han-sans-path}/SpoqaHanSansJP-Thin/SpoqaHanSansJP-Thin.woff) format('woff');
+    src: url('#{$spoqa-han-sans-path}/SpoqaHanSansJP-Thin/SpoqaHanSansJP-Thin.eot');
+    src: local('SpoqaHanSansJP-Thin'),
+    url('#{$spoqa-han-sans-path}/SpoqaHanSansJP-Thin/SpoqaHanSansJP-Thin.eot?#iefix') format('embedded-opentype'),
+    url('#{$spoqa-han-sans-path}/SpoqaHanSansJP-Thin/SpoqaHanSansJP-Thin.woff2') format('woff2'),
+    url('#{$spoqa-han-sans-path}/SpoqaHanSansJP-Thin/SpoqaHanSansJP-Thin.woff') format('woff'),
+    url('#{$spoqa-han-sans-path}/SpoqaHanSansJP-Thin/SpoqaHanSansJP-Thin.ttf') format('truetype'),
+    url('#{$spoqa-han-sans-path}/SpoqaHanSansJP-Thin/SpoqaHanSansJP-Thin.svg#SpoqaHanSansJP') format('svg');
 }

--- a/scss/spoqa-han-sans-kr.scss
+++ b/scss/spoqa-han-sans-kr.scss
@@ -3,29 +3,35 @@ $spoqa-han-sans-path: "../Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset(webfont%
 @font-face {
     font-family: 'Spoqa Han Sans';
     font-weight: 700;
-    src: local('SpoqaHanSans-Bold'), local('SpoqaHanSans-Bold'),
-    url('#{$spoqa-han-sans-path}/SpoqaHanSans-Bold/SpoqaHanSans-Bold.eot') format('eot'),
-    url('#{$spoqa-han-sans-path}/SpoqaHanSans-Bold/SpoqaHanSans-Bold.svg') format('svg'),
+    src: url('#{$spoqa-han-sans-path}/SpoqaHanSans-Bold/SpoqaHanSans-Bold.eot');
+    src: local('SpoqaHanSans-Bold'),
+    url('#{$spoqa-han-sans-path}/SpoqaHanSans-Bold/SpoqaHanSans-Bold.eot?#iefix') format('embedded-opentype'),
+    url('#{$spoqa-han-sans-path}/SpoqaHanSans-Bold/SpoqaHanSans-Bold.woff2') format('woff2'),
+    url('#{$spoqa-han-sans-path}/SpoqaHanSans-Bold/SpoqaHanSans-Bold.woff') format('woff'),
     url('#{$spoqa-han-sans-path}/SpoqaHanSans-Bold/SpoqaHanSans-Bold.ttf') format('truetype'),
-    url('#{$spoqa-han-sans-path}/SpoqaHanSans-Bold/SpoqaHanSans-Bold.woff') format('woff');
+    url('#{$spoqa-han-sans-path}/SpoqaHanSans-Bold/SpoqaHanSans-Bold.svg#SpoqaHanSans') format('svg');
 }
 
 @font-face {
     font-family: 'Spoqa Han Sans';
     font-weight: 400;
-    src: local('SpoqaHanSans-Regular'), local('SpoqaHanSans-Regular'),
-    url('#{$spoqa-han-sans-path}/SpoqaHanSans-Regular/SpoqaHanSans-Regular.eot') format('eot'),
-    url('#{$spoqa-han-sans-path}/SpoqaHanSans-Regular/SpoqaHanSans-Regular.svg') format('svg'),
+    src: url('#{$spoqa-han-sans-path}/SpoqaHanSans-Regular/SpoqaHanSans-Regular.eot');
+    src: local('SpoqaHanSans-Regular'),
+    url('#{$spoqa-han-sans-path}/SpoqaHanSans-Regular/SpoqaHanSans-Regular.eot?#iefix') format('embedded-opentype'),
+    url('#{$spoqa-han-sans-path}/SpoqaHanSans-Regular/SpoqaHanSans-Regular.woff2') format('woff2'),
+    url('#{$spoqa-han-sans-path}/SpoqaHanSans-Regular/SpoqaHanSans-Regular.woff') format('woff'),
     url('#{$spoqa-han-sans-path}/SpoqaHanSans-Regular/SpoqaHanSans-Regular.ttf') format('truetype'),
-    url('#{$spoqa-han-sans-path}/SpoqaHanSans-Regular/SpoqaHanSans-Regular.woff') format('woff');
+    url('#{$spoqa-han-sans-path}/SpoqaHanSans-Regular/SpoqaHanSans-Regular.svg#SpoqaHanSans') format('svg');
 }
 
 @font-face {
     font-family: 'Spoqa Han Sans';
     font-weight: 200;
-    src: local('SpoqaHanSans-Thin'), local('SpoqaHanSans-Thin'),
-    url('#{$spoqa-han-sans-path}/SpoqaHanSans-Thin/SpoqaHanSans-Thin.eot') format('eot'),
-    url('#{$spoqa-han-sans-path}/SpoqaHanSans-Thin/SpoqaHanSans-Thin.svg') format('svg'),
+    src: url('#{$spoqa-han-sans-path}/SpoqaHanSans-Thin/SpoqaHanSans-Thin.eot');
+    src: local('SpoqaHanSans-Thin'),
+    url('#{$spoqa-han-sans-path}/SpoqaHanSans-Thin/SpoqaHanSans-Thin.eot?#iefix') format('embedded-opentype'),
+    url('#{$spoqa-han-sans-path}/SpoqaHanSans-Thin/SpoqaHanSans-Thin.woff2') format('woff2'),
+    url('#{$spoqa-han-sans-path}/SpoqaHanSans-Thin/SpoqaHanSans-Thin.woff') format('woff'),
     url('#{$spoqa-han-sans-path}/SpoqaHanSans-Thin/SpoqaHanSans-Thin.ttf') format('truetype'),
-    url('#{$spoqa-han-sans-path}/SpoqaHanSans-Thin/SpoqaHanSans-Thin.woff') format('woff');
+    url('#{$spoqa-han-sans-path}/SpoqaHanSans-Thin/SpoqaHanSans-Thin.svg#SpoqaHanSans') format('svg');
 }


### PR DESCRIPTION
Fixes https://github.com/spoqa/spoqa-han-sans/issues/98

This commit introduces better @font-face rule for maxium compatibility and lower payload.
Details:

- WOFF precedes Truetype
- introduce WOFF2 (not included before)
- Better legacy env. support