### PR TITLE
Prune the contaminated credential and replace it [VD-2183] (for 2.0-webpage)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "_sass/dooboo"]
 	path = _sass/dooboo
-	url = https://-d-o-d-o-:75c2cd903546286d3b81e4cff1c4869aad544615@git.spoqa.com/scm/des/style-sheets.git
+	url = https://spoqa-web-chef:%37%37%30%39%63%37%34%35%34%33%65%39%36%62%39%65%63%30%39%32%31%34%33%61%38%64%38%37%33%31%33%33%34%30%31%31%63%38%65%61@github.com/spoqa/dooboo.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "_sass/dooboo"]
+	path = _sass/dooboo
+	url = https://-d-o-d-o-:75c2cd903546286d3b81e4cff1c4869aad544615@git.spoqa.com/scm/des/style-sheets.git

--- a/css/SpoqaHanSans-jp.css
+++ b/css/SpoqaHanSans-jp.css
@@ -24,29 +24,35 @@
 @font-face {
     font-family: 'Spoqa Han Sans JP';
     font-weight: 700;
-    src: local('SpoqaHanSansJP-Bold'), local('SpoqaHanSansJP-Bold'),
-    url(https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset%28webfont%20inclued%29/SpoqaHanSansJP-Bold/SpoqaHanSansJP-Bold.eot) format('eot'),
-    url(https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset%28webfont%20inclued%29/SpoqaHanSansJP-Bold/SpoqaHanSansJP-Bold.svg) format('svg'),
-    url(https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset%28webfont%20inclued%29/SpoqaHanSansJP-Bold/SpoqaHanSansJP-Bold.ttf) format('truetype'),
-    url(https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset%28webfont%20inclued%29/SpoqaHanSansJP-Bold/SpoqaHanSansJP-Bold.woff) format('woff');
+    src: url('https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset(webfont%20inclued)/SpoqaHanSansJP-Bold/SpoqaHanSansJP-Bold.eot');
+    src: local('SpoqaHanSansJP-Bold'),
+    url('https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset(webfont%20inclued)/SpoqaHanSansJP-Bold/SpoqaHanSansJP-Bold.eot?#iefix') format('embedded-opentype'),
+    url('https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset(webfont%20inclued)/SpoqaHanSansJP-Bold/SpoqaHanSansJP-Bold.woff2') format('woff2'),
+    url('https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset(webfont%20inclued)/SpoqaHanSansJP-Bold/SpoqaHanSansJP-Bold.woff') format('woff'),
+    url('https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset(webfont%20inclued)/SpoqaHanSansJP-Bold/SpoqaHanSansJP-Bold.ttf') format('truetype'),
+    url('https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset(webfont%20inclued)/SpoqaHanSansJP-Bold/SpoqaHanSansJP-Bold.svg#SpoqaHanSansJP') format('svg');
 }
 
 @font-face {
     font-family: 'Spoqa Han Sans JP';
     font-weight: 400;
-    src: local('SpoqaHanSansJP-Regular'), local('SpoqaHanSansJP-Regular'),
-    url(https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset%28webfont%20inclued%29/SpoqaHanSansJP-Regular/SpoqaHanSansJP-Regular.eot) format('eot'),
-    url(https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset%28webfont%20inclued%29/SpoqaHanSansJP-Regular/SpoqaHanSansJP-Regular.svg) format('svg'),
-    url(https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset%28webfont%20inclued%29/SpoqaHanSansJP-Regular/SpoqaHanSansJP-Regular.ttf) format('truetype'),
-    url(https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset%28webfont%20inclued%29/SpoqaHanSansJP-Regular/SpoqaHanSansJP-Regular.woff) format('woff');
+    src: url('https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset(webfont%20inclued)/SpoqaHanSansJP-Regular/SpoqaHanSansJP-Regular.eot');
+    src: local('SpoqaHanSansJP-Regular'),
+    url('https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset(webfont%20inclued)/SpoqaHanSansJP-Regular/SpoqaHanSansJP-Regular.eot?#iefix') format('embedded-opentype'),
+    url('https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset(webfont%20inclued)/SpoqaHanSansJP-Regular/SpoqaHanSansJP-Regular.woff2') format('woff2'),
+    url('https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset(webfont%20inclued)/SpoqaHanSansJP-Regular/SpoqaHanSansJP-Regular.woff') format('woff'),
+    url('https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset(webfont%20inclued)/SpoqaHanSansJP-Regular/SpoqaHanSansJP-Regular.ttf') format('truetype'),
+    url('https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset(webfont%20inclued)/SpoqaHanSansJP-Regular/SpoqaHanSansJP-Regular.svg#SpoqaHanSansJP') format('svg');
 }
 
 @font-face {
     font-family: 'Spoqa Han Sans JP';
     font-weight: 200;
-    src: local('SpoqaHanSansJP-Thin'), local('SpoqaHanSansJP-Thin'),
-    url(https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset%28webfont%20inclued%29/SpoqaHanSansJP-Thin/SpoqaHanSansJP-Thin.eot) format('eot'),
-    url(https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset%28webfont%20inclued%29/SpoqaHanSansJP-Thin/SpoqaHanSansJP-Thin.svg) format('svg'),
-    url(https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset%28webfont%20inclued%29/SpoqaHanSansJP-Thin/SpoqaHanSansJP-Thin.ttf) format('truetype'),
-    url(https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset%28webfont%20inclued%29/SpoqaHanSansJP-Thin/SpoqaHanSansJP-Thin.woff) format('woff');
+    src: url('https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset(webfont%20inclued)/SpoqaHanSansJP-Thin/SpoqaHanSansJP-Thin.eot');
+    src: local('SpoqaHanSansJP-Thin'),
+    url('https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset(webfont%20inclued)/SpoqaHanSansJP-Thin/SpoqaHanSansJP-Thin.eot?#iefix') format('embedded-opentype'),
+    url('https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset(webfont%20inclued)/SpoqaHanSansJP-Thin/SpoqaHanSansJP-Thin.woff2') format('woff2'),
+    url('https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset(webfont%20inclued)/SpoqaHanSansJP-Thin/SpoqaHanSansJP-Thin.woff') format('woff'),
+    url('https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset(webfont%20inclued)/SpoqaHanSansJP-Thin/SpoqaHanSansJP-Thin.ttf') format('truetype'),
+    url('https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans_JP/Spoqa%20Han%20sans%20JP_subset(webfont%20inclued)/SpoqaHanSansJP-Thin/SpoqaHanSansJP-Thin.svg#SpoqaHanSansJP') format('svg');
 }

--- a/css/SpoqaHanSans-kr.css
+++ b/css/SpoqaHanSans-kr.css
@@ -24,29 +24,35 @@
 @font-face {
     font-family: 'Spoqa Han Sans';
     font-weight: 700;
-    src: local('SpoqaHanSans-Bold'), local('SpoqaHanSans-Bold'),
-    url(https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset%28webfont%20inclued%29/SpoqaHanSans-Bold/SpoqaHanSans-Bold.eot) format('eot'),
-    url(https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset%28webfont%20inclued%29/SpoqaHanSans-Bold/SpoqaHanSans-Bold.svg) format('svg'),
-    url(https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset%28webfont%20inclued%29/SpoqaHanSans-Bold/SpoqaHanSans-Bold.ttf) format('truetype'),
-    url(https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset%28webfont%20inclued%29/SpoqaHanSans-Bold/SpoqaHanSans-Bold.woff) format('woff');
+    src: url('https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset(webfont%20inclued)/SpoqaHanSans-Bold/SpoqaHanSans-Bold.eot');
+    src: local('SpoqaHanSans-Bold'),
+    url('https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset(webfont%20inclued)/SpoqaHanSans-Bold/SpoqaHanSans-Bold.eot?#iefix') format('embedded-opentype'),
+    url('https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset(webfont%20inclued)/SpoqaHanSans-Bold/SpoqaHanSans-Bold.woff2') format('woff2'),
+    url('https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset(webfont%20inclued)/SpoqaHanSans-Bold/SpoqaHanSans-Bold.woff') format('woff'),
+    url('https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset(webfont%20inclued)/SpoqaHanSans-Bold/SpoqaHanSans-Bold.ttf') format('truetype'),
+    url('https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset(webfont%20inclued)/SpoqaHanSans-Bold/SpoqaHanSans-Bold.svg#SpoqaHanSans') format('svg');
 }
 
 @font-face {
     font-family: 'Spoqa Han Sans';
     font-weight: 400;
-    src: local('SpoqaHanSans-Regular'), local('SpoqaHanSans-Regular'),
-    url(https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset%28webfont%20inclued%29/SpoqaHanSans-Regular/SpoqaHanSans-Regular.eot) format('eot'),
-    url(https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset%28webfont%20inclued%29/SpoqaHanSans-Regular/SpoqaHanSans-Regular.svg) format('svg'),
-    url(https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset%28webfont%20inclued%29/SpoqaHanSans-Regular/SpoqaHanSans-Regular.ttf) format('truetype'),
-    url(https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset%28webfont%20inclued%29/SpoqaHanSans-Regular/SpoqaHanSans-Regular.woff) format('woff');
+    src: url('https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset(webfont%20inclued)/SpoqaHanSans-Regular/SpoqaHanSans-Regular.eot');
+    src: local('SpoqaHanSans-Regular'),
+    url('https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset(webfont%20inclued)/SpoqaHanSans-Regular/SpoqaHanSans-Regular.eot?#iefix') format('embedded-opentype'),
+    url('https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset(webfont%20inclued)/SpoqaHanSans-Regular/SpoqaHanSans-Regular.woff2') format('woff2'),
+    url('https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset(webfont%20inclued)/SpoqaHanSans-Regular/SpoqaHanSans-Regular.woff') format('woff'),
+    url('https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset(webfont%20inclued)/SpoqaHanSans-Regular/SpoqaHanSans-Regular.ttf') format('truetype'),
+    url('https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset(webfont%20inclued)/SpoqaHanSans-Regular/SpoqaHanSans-Regular.svg#SpoqaHanSans') format('svg');
 }
 
 @font-face {
     font-family: 'Spoqa Han Sans';
     font-weight: 200;
-    src: local('SpoqaHanSans-Thin'), local('SpoqaHanSans-Thin'),
-    url(https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset%28webfont%20inclued%29/SpoqaHanSans-Thin/SpoqaHanSans-Thin.eot) format('eot'),
-    url(https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset%28webfont%20inclued%29/SpoqaHanSans-Thin/SpoqaHanSans-Thin.svg) format('svg'),
-    url(https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset%28webfont%20inclued%29/SpoqaHanSans-Thin/SpoqaHanSans-Thin.ttf) format('truetype'),
-    url(https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset%28webfont%20inclued%29/SpoqaHanSans-Thin/SpoqaHanSans-Thin.woff) format('woff');
+    src: url('https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset(webfont%20inclued)/SpoqaHanSans-Thin/SpoqaHanSans-Thin.eot');
+    src: local('SpoqaHanSans-Thin'),
+    url('https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset(webfont%20inclued)/SpoqaHanSans-Thin/SpoqaHanSans-Thin.eot?#iefix') format('embedded-opentype'),
+    url('https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset(webfont%20inclued)/SpoqaHanSans-Thin/SpoqaHanSans-Thin.woff2') format('woff2'),
+    url('https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset(webfont%20inclued)/SpoqaHanSans-Thin/SpoqaHanSans-Thin.woff') format('woff'),
+    url('https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset(webfont%20inclued)/SpoqaHanSans-Thin/SpoqaHanSans-Thin.ttf') format('truetype'),
+    url('https://cdn.rawgit.com/spoqa/spoqa-han-sans/master/Subset/SpoqaHanSans/Spoqa%20Han%20sans_subset(webfont%20inclued)/SpoqaHanSans-Thin/SpoqaHanSans-Thin.svg#SpoqaHanSans') format('svg');
 }


### PR DESCRIPTION
<https://i.spoqa.com/browse/VD-2183>

#102 가 같이 끼어 들어가는데, 코드만 봤을 때는 `gh-pages`에 들어간 개선점을 이쪽 브랜치에도 반영하는 것처럼 보여서 일단 두어 보았습니다. /cc @yeun 