### PR TITLE
스포카 한 산스 단편적 사실들 글의 링크를 바로잡습니다.

### DIFF
--- a/en-US/index.html
+++ b/en-US/index.html
@@ -82,7 +82,7 @@ layout: default
                 <div class="column-content">
                   We thank everyone for being a big fan of Spoqa Hans Sans. We received helpful feedbacks and comments. As developers of Spoqa Han Sans, we discoverd more to elaborate in our product. Now we release the latest version of Spoqa Han Sans. Let’s take a look around.
                   <div class="link-underline">
-                    <a target="_blank" href="https://spoqa.github.io/2017/02/15/shs-trivia.html">Some fragmentary facts of Spoqa Han Sans</a>
+                    <a target="_blank" href="https://spoqa.github.io/2017/02/15/SHS-trivia.html">Some fragmentary facts of Spoqa Han Sans</a>
                   </div>
                 </div>
               </div>

--- a/ko-KR/index.html
+++ b/ko-KR/index.html
@@ -82,7 +82,7 @@ layout: default
                 <div class="column-content">
                   스포카 한 산스를 처음 공개하고 많은 사랑을 받았습니다.<br>그만큼 다양한 피드백을 들었고, 내부적으로 직접 사용하면서도 개선의 필요성을 느꼈습니다. <br>이를 반영해 개선한 스포카 한 산스를 공개합니다. 
                   <div class="link-underline">
-                    <a target="_blank" href="https://spoqa.github.io/2017/02/15/shs-trivia.html">스포카 한 산스 2.0에 관한 몇가지 단편적 사실들</a>
+                    <a target="_blank" href="https://spoqa.github.io/2017/02/15/SHS-trivia.html">스포카 한 산스 2.0에 관한 몇가지 단편적 사실들</a>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
스포카 한 산스 단편적 사실들 글의 링크를 바로잡습니다.

`shs-trivia...`, 소문자로 써져있어서 읽어오지 못했던 것을 `SHS-trivia` 같이 대문자로 적습니다.
