### PR TITLE
(HOTFIX) Add Facebook Open Graph and Twitter Card data into redirect.html

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,8 +3,8 @@
   <head>
     <meta charset="UTF-8">
     <title>Spoqa Han Sans</title>
-    <link rel="canonical" href="{{ site.base_path }}">
-    <meta property="og:url" content="{{ site.base_path }}">
+    <link rel="canonical" href="{{ site.base_path }}{{ page.url }}">
+    <meta property="og:url" content="{{ site.base_path }}{{ page.url }}">
     <meta property="og:type" content="website">
     <meta property="og:title" content="Spoqa Han Sans">
     <meta property="og:description" content="Spoqa unveil the new version of Spoqa Han Sans, which has evolved in many ways. | 여러모로 개선을 거쳐 진화한 스포카 한 산스 두 번째 버전을 공개합니다. | これまでいろいろ改善して進化した新しいスポカーハンサンスを公開します。">

--- a/_layouts/redirect.html
+++ b/_layouts/redirect.html
@@ -3,7 +3,17 @@
   <head>
     <meta charset="utf-8">
     <title>Spoqa Han Sans</title>
-    <link rel="canonical" href="{{ site.base_path }}">
+    <link rel="canonical" href="{{ site.base_path }}{{ page.url }}">
+    <meta property="og:url" content="{{ site.base_path }}{{ page.url }}">
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="Spoqa Han Sans">
+    <meta property="og:description" content="Spoqa unveil the new version of Spoqa Han Sans, which has evolved in many ways. | 여러모로 개선을 거쳐 진화한 스포카 한 산스 두 번째 버전을 공개합니다. | これまでいろいろ改善して進化した新しいスポカーハンサンスを公開します。">
+    <meta property="og:image" content="{{ site.base_path }}images/preview.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:site" content="@spoqa">
+    <meta name="twitter:title" content="Spoqa Han Sans">
+    <meta name="twitter:description" content="Spoqa unveil the new version of Spoqa Han Sans, which has evolved in many ways. | 여러모로 개선을 거쳐 진화한 스포카 한 산스 두 번째 버전을 공개합니다. | これまでいろいろ改善して進化した新しいスポカーハンサンスを公開します。">
+    <meta name="twtiter:image" content="{{ site.base_path }}images/preview.png">
     <script type="text/javascript">
       // a list of mappings, the keys are what we might get from a browser, and the
       // values are what URL we should send that value to.


### PR DESCRIPTION
리다이렉트 페이지에 오픈 그래프와 트위터 카드 정보를 넣습니다.

오픈 그래프 정보를 국제화할 수 있지만 Jekyll이 스태틱 서빙만 지원하기 때문에 `fb_locale` 쿼리 스트링을 받을 수 없어서 사용할 방법이 달리 없습니다. 따라서 종전 오픈그래프 정보를 그대로 이용합니다.

@heejongahn @young-hwa 리뷰 부탁합니다.