### PR TITLE
로컬에 스한스 네오가 설치되지 않은 경우 소개 페이지에서 폰트를 찾지 못하는 문제 수정

### DIFF
--- a/_includes/ko_kr.html
+++ b/_includes/ko_kr.html
@@ -23,7 +23,7 @@
 
 <section class="section section-header hero-wrap">
   <div class="container-fluid">
-    <h1 class="header-text"><span class="header-text-700">Spoqa Han Sans Neo is a font that improves the previous Spoqa Han Sans.</span> <span style="font-family:'Spoqa Han Sans Neo'; font-weight: 500;">It supports more diverse weights and improves the readability and uniformity.<span style="color: #4c80f1;"> 스포카 한 산스 네오</span>는 기존의 스포카 한 산스를 개선한 글꼴입니다.</span> <span class="header-text-400">더 다양한 웨이트를 지원하고, 가독성과 통일성을 향상했습니다.</span> <span class="header-text-300">スポカハンサンスネオは従来のスポカハンサンスを改善したフォントです。</span> <span class="JP-word-break header-text-100">より多彩なウェイトをサポートし、可読性と統一性を向上しました。</span></h1>
+    <h1 class="header-text"><span class="header-text-700">Spoqa Han Sans Neo is a font that improves the previous Spoqa Han Sans.</span> <span style="font-weight: 500;">It supports more diverse weights and improves the readability and uniformity.<span style="color: #4c80f1;"> 스포카 한 산스 네오</span>는 기존의 스포카 한 산스를 개선한 글꼴입니다.</span> <span class="header-text-400">더 다양한 웨이트를 지원하고, 가독성과 통일성을 향상했습니다.</span> <span class="header-text-300">スポカハンサンスネオは従来のスポカハンサンスを改善したフォントです。</span> <span class="JP-word-break header-text-100">より多彩なウェイトをサポートし、可読性と統一性を向上しました。</span></h1>
   </div>
 </section>
 <hr />
@@ -74,7 +74,7 @@
               용량 다이어트를 감행해 웹 페이지에서도<br>부담 없이 사용할 수 있습니다.
             </div>
             <div class="column-content">
-              노토 산스를 포함한 한글꼴은 전체 용량이 크기 때문에 웹에서 사용하기에 좋지 않습니다. 이에 11,172자에서 한글꼴 완성형의 최소 단위인 2,350자로 줄였습니다. 첫 버전의 용량은 16MB에서 441KB 수준으로 줄었습니다. 
+              노토 산스를 포함한 한글꼴은 전체 용량이 크기 때문에 웹에서 사용하기에 좋지 않습니다. 이에 11,172자에서 한글꼴 완성형의 최소 단위인 2,350자로 줄였습니다. 첫 버전의 용량은 16MB에서 441KB 수준으로 줄었습니다.
               <div class="link-underline">
                 <a target="_blank" href="https://spoqa.github.io/2016/06/03/localize-type-setting.html">스포카 한 산스와 글꼴 경량화</a>
               </div>
@@ -87,7 +87,7 @@
               기존 스포카 한 산스를 개선한<br>세 번째 버전, 네오를 공개합니다.
             </div>
             <div class="column-content">
-              스포카 한 산스를 처음 공개하고 많은 사랑을 받았습니다. 그만큼 다양한 피드백을 들었고, 내부적으로 직접 사용하면서도 개선의 필요성을 느꼈습니다. 이를 반영해 개선한 스포카 한 산스 네오를 공개합니다. 
+              스포카 한 산스를 처음 공개하고 많은 사랑을 받았습니다. 그만큼 다양한 피드백을 들었고, 내부적으로 직접 사용하면서도 개선의 필요성을 느꼈습니다. 이를 반영해 개선한 스포카 한 산스 네오를 공개합니다.
               <div class="section-description" style="padding-top: 20px;">
                   *제작에 도움을 주신 위예진 디자이너님께 감사드립니다.
               </div>
@@ -192,7 +192,7 @@
       <h3 class="section-title">스포카 한 산스 네오 써보기</h3>
       <div class="section-description">
         아래 섹션에 원하는 글자를 입력해 스포카 한 산스 네오를 웹 페이지에서 써보세요!<br>
-        원하는 글자 굵기를 선택할 수 있으며, 글자 크기, 글줄 사이, 글자 사이 및 색상을 변경할 수 있습니다. 
+        원하는 글자 굵기를 선택할 수 있으며, 글자 크기, 글줄 사이, 글자 사이 및 색상을 변경할 수 있습니다.
       </div>
       <div class="preview-area">
 <div class="control-bar">

--- a/_includes/ko_kr.html
+++ b/_includes/ko_kr.html
@@ -23,7 +23,7 @@
 
 <section class="section section-header hero-wrap">
   <div class="container-fluid">
-    <h1 class="header-text"><span class="header-text-700">Spoqa Han Sans Neo is a font that improves the previous Spoqa Han Sans.</span> <span style="font-weight: 500;">It supports more diverse weights and improves the readability and uniformity.<span style="color: #4c80f1;"> 스포카 한 산스 네오</span>는 기존의 스포카 한 산스를 개선한 글꼴입니다.</span> <span class="header-text-400">더 다양한 웨이트를 지원하고, 가독성과 통일성을 향상했습니다.</span> <span class="header-text-300">スポカハンサンスネオは従来のスポカハンサンスを改善したフォントです。</span> <span class="JP-word-break header-text-100">より多彩なウェイトをサポートし、可読性と統一性を向上しました。</span></h1>
+    <h1 class="header-text"><span class="header-text-700">Spoqa Han Sans Neo is a font that improves the previous Spoqa Han Sans.</span> <span class="header-text-500">It supports more diverse weights and improves the readability and uniformity.<span style="color: #4c80f1;"> 스포카 한 산스 네오</span>는 기존의 스포카 한 산스를 개선한 글꼴입니다.</span> <span class="header-text-400">더 다양한 웨이트를 지원하고, 가독성과 통일성을 향상했습니다.</span> <span class="header-text-300">スポカハンサンスネオは従来のスポカハンサンスを改善したフォントです。</span> <span class="JP-word-break header-text-100">より多彩なウェイトをサポートし、可読性と統一性を向上しました。</span></h1>
   </div>
 </section>
 <hr />

--- a/en-US/index.html
+++ b/en-US/index.html
@@ -28,7 +28,7 @@ og_url: https://spoqa.github.io/spoqa-han-sans/en-US/
 
 <section class="section section-header hero-wrap">
   <div class="container-fluid">
-    <h1 class="header-text"><span class="header-text-700">Spoqa Han Sans Neo is a font that improves the previous Spoqa Han Sans.</span> <span style="font-weight: 500;">It supports more diverse weights and improves the readability and uniformity.<span style="color: #4c80f1;"> 스포카 한 산스 네오</span>는 기존의 스포카 한 산스를 개선한 글꼴입니다.</span> <span class="header-text-400">더 다양한 웨이트를 지원하고, 가독성과 통일성을 향상했습니다.</span> <span class="header-text-300">スポカハンサンスネオは従来のスポカハンサンスを改善したフォントです。</span> <span class="JP-word-break header-text-100">より多彩なウェイトをサポートし、可読性と統一性を向上しました。</span></h1>
+    <h1 class="header-text"><span class="header-text-700">Spoqa Han Sans Neo is a font that improves the previous Spoqa Han Sans.</span> <span class="header-text-500">It supports more diverse weights and improves the readability and uniformity.<span style="color: #4c80f1;"> 스포카 한 산스 네오</span>는 기존의 스포카 한 산스를 개선한 글꼴입니다.</span> <span class="header-text-400">더 다양한 웨이트를 지원하고, 가독성과 통일성을 향상했습니다.</span> <span class="header-text-300">スポカハンサンスネオは従来のスポカハンサンスを改善したフォントです。</span> <span class="JP-word-break header-text-100">より多彩なウェイトをサポートし、可読性と統一性を向上しました。</span></h1>
   </div>
 </section>
 <hr />

--- a/en-US/index.html
+++ b/en-US/index.html
@@ -28,7 +28,7 @@ og_url: https://spoqa.github.io/spoqa-han-sans/en-US/
 
 <section class="section section-header hero-wrap">
   <div class="container-fluid">
-    <h1 class="header-text"><span class="header-text-700">Spoqa Han Sans Neo is a font that improves the previous Spoqa Han Sans.</span> <span style="font-family:'Spoqa Han Sans Neo'; font-weight: 500;">It supports more diverse weights and improves the readability and uniformity.<span style="color: #4c80f1;"> 스포카 한 산스 네오</span>는 기존의 스포카 한 산스를 개선한 글꼴입니다.</span> <span class="header-text-400">더 다양한 웨이트를 지원하고, 가독성과 통일성을 향상했습니다.</span> <span class="header-text-300">スポカハンサンスネオは従来のスポカハンサンスを改善したフォントです。</span> <span class="JP-word-break header-text-100">より多彩なウェイトをサポートし、可読性と統一性を向上しました。</span></h1>
+    <h1 class="header-text"><span class="header-text-700">Spoqa Han Sans Neo is a font that improves the previous Spoqa Han Sans.</span> <span style="font-weight: 500;">It supports more diverse weights and improves the readability and uniformity.<span style="color: #4c80f1;"> 스포카 한 산스 네오</span>는 기존의 스포카 한 산스를 개선한 글꼴입니다.</span> <span class="header-text-400">더 다양한 웨이트를 지원하고, 가독성과 통일성을 향상했습니다.</span> <span class="header-text-300">スポカハンサンスネオは従来のスポカハンサンスを改善したフォントです。</span> <span class="JP-word-break header-text-100">より多彩なウェイトをサポートし、可読性と統一性を向上しました。</span></h1>
   </div>
 </section>
 <hr />


### PR DESCRIPTION
안녕하세요, 로컬에 스한스 네오가 설치되지 않은 경우 소개 페이지에서 정상적으로 폰트가 렌더링되지 않고 있는 문제를 발견하여 수정 PR을 올립니다.

특히 사파리에서는 폴백 폰트가 애플명조이기 때문에 아래 스크린샷처럼 좀 더 문제가 도드라져 보이는데요,

<img width="1072" alt="스크린샷 2020-12-01 오전 11 27 23" src="https://user-images.githubusercontent.com/1343747/100696674-6dea7800-33d7-11eb-9cf8-1e5eabb2e19a.png">

`gh_pages` 브랜치의 `_includes/ko_kr.html`과 `en-US/index.html`에서 `font-family:'Spoqa Han Sans Neo';`로 폰트가 설정돼있는 부분에서 문제가 발생하고 있었구요, 코드를 살펴보니 `.header-text-500`이 이미 정의돼있는데 사용되지 않고 있는 것을 발견해 `class="header-text-500"`을 사용하도록 수정해봤습니다.

`css/SpoqaHanSansNeo.css`의 `@font-face`에서 `font-family`가 `Spoqa Han Sans`로만 정의가 돼있고, `Spoqa Han Sans Neo`로는 정의가 돼있지 않은 것도 브라우저 기본 폰트 렌더링의 원인이긴 한데요, 이 부분은 제가 의도를 정확하게 모르는 관계로 수정하지 않았습니다.

로컬에서 빌드한 후 `serve`를 실행했을 때의 수정 결과 스크린샷도 첨부합니다.
<img width="1465" alt="스크린샷 2020-12-01 오후 1 12 45" src="https://user-images.githubusercontent.com/1343747/100696969-21536c80-33d8-11eb-9887-494848c1b56e.png">