### PR TITLE
css를 의도에 맞추어서 예전 버전으로 롤백합니다.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ release
 site/
 
 .DS_Store
+
+*.yml

--- a/css/SpoqaHanSans-kr.css
+++ b/css/SpoqaHanSans-kr.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 Spoqa, Inc.
+ * Copyright (c) 2015 Spoqa, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -26,19 +26,9 @@
     font-weight: 700;
     font-display: swap;
     src: local('Spoqa Han Sans Bold'),
-    url('../Subset/SpoqaHanSansNeo/SpoqaHanSansNeo-Bold.woff2') format('woff2'),
-    url('../Subset/SpoqaHanSansNeo/SpoqaHanSansNeo-Bold.woff') format('woff'),
-    url('../Subset/SpoqaHanSansNeo/SpoqaHanSansNeo-Bold.ttf') format('truetype');
-}
-
-@font-face {
-    font-family: 'Spoqa Han Sans';
-    font-weight: 500;
-    font-display: swap;
-    src: local('Spoqa Han Sans Medium'),
-    url('../Subset/SpoqaHanSansNeo/SpoqaHanSansNeo-Medium.woff2') format('woff2'),
-    url('../Subset/SpoqaHanSansNeo/SpoqaHanSansNeo-Medium.woff') format('woff'),
-    url('../Subset/SpoqaHanSansNeo/SpoqaHanSansNeo-Medium.ttf') format('truetype');
+    url('../Subset/SpoqaHanSans/SpoqaHanSansBold.woff2') format('woff2'),
+    url('../Subset/SpoqaHanSans/SpoqaHanSansBold.woff') format('woff'),
+    url('../Subset/SpoqaHanSans/SpoqaHanSansBold.ttf') format('truetype');
 }
 
 @font-face {
@@ -46,9 +36,9 @@
     font-weight: 400;
     font-display: swap;
     src: local('Spoqa Han Sans Regular'),
-    url('../Subset/SpoqaHanSansNeo/SpoqaHanSansNeo-Regular.woff2') format('woff2'),
-    url('../Subset/SpoqaHanSansNeo/SpoqaHanSansNeo-Regular.woff') format('woff'),
-    url('../Subset/SpoqaHanSansNeo/SpoqaHanSansNeo-Regular.ttf') format('truetype');
+    url('../Subset/SpoqaHanSans/SpoqaHanSansRegular.woff2') format('woff2'),
+    url('../Subset/SpoqaHanSans/SpoqaHanSansRegular.woff') format('woff'),
+    url('../Subset/SpoqaHanSans/SpoqaHanSansRegular.ttf') format('truetype');
 }
 
 @font-face {
@@ -56,9 +46,9 @@
     font-weight: 300;
     font-display: swap;
     src: local('Spoqa Han Sans Light'),
-    url('../Subset/SpoqaHanSansNeo/SpoqaHanSansNeo-Light.woff2') format('woff2'),
-    url('../Subset/SpoqaHanSansNeo/SpoqaHanSansNeo-Light.woff') format('woff'),
-    url('../Subset/SpoqaHanSansNeo/SpoqaHanSansNeo-Light.ttf') format('truetype');
+    url('../Subset/SpoqaHanSans/SpoqaHanSansLight.woff2') format('woff2'),
+    url('../Subset/SpoqaHanSans/SpoqaHanSansLight.woff') format('woff'),
+    url('../Subset/SpoqaHanSans/SpoqaHanSansLight.ttf') format('truetype');
 }
 
 @font-face {
@@ -66,57 +56,7 @@
     font-weight: 100;
     font-display: swap;
     src: local('Spoqa Han Sans Thin'),
-    url('../Subset/SpoqaHanSansNeo/SpoqaHanSansNeo-Thin.woff2') format('woff2'),
-    url('../Subset/SpoqaHanSansNeo/SpoqaHanSansNeo-Thin.woff') format('woff'),
-    url('../Subset/SpoqaHanSansNeo/SpoqaHanSansNeo-Thin.ttf') format('truetype');
-}
-
-@font-face {
-    font-family: 'Spoqa Han Sans Neo';
-    font-weight: 700;
-    font-display: swap;
-    src: local('Spoqa Han Sans Neo Bold'),
-    url('../Subset/SpoqaHanSansNeo/SpoqaHanSansNeo-Bold.woff2') format('woff2'),
-    url('../Subset/SpoqaHanSansNeo/SpoqaHanSansNeo-Bold.woff') format('woff'),
-    url('../Subset/SpoqaHanSansNeo/SpoqaHanSansNeo-Bold.ttf') format('truetype');
-}
-
-@font-face {
-    font-family: 'Spoqa Han Sans Neo';
-    font-weight: 500;
-    font-display: swap;
-    src: local('Spoqa Han Sans Neo Medium'),
-    url('../Subset/SpoqaHanSansNeo/SpoqaHanSansNeo-Medium.woff2') format('woff2'),
-    url('../Subset/SpoqaHanSansNeo/SpoqaHanSansNeo-Medium.woff') format('woff'),
-    url('../Subset/SpoqaHanSansNeo/SpoqaHanSansNeo-Medium.ttf') format('truetype');
-}
-
-@font-face {
-    font-family: 'Spoqa Han Sans Neo';
-    font-weight: 400;
-    font-display: swap;
-    src: local('Spoqa Han Sans Neo Regular'),
-    url('../Subset/SpoqaHanSansNeo/SpoqaHanSansNeo-Regular.woff2') format('woff2'),
-    url('../Subset/SpoqaHanSansNeo/SpoqaHanSansNeo-Regular.woff') format('woff'),
-    url('../Subset/SpoqaHanSansNeo/SpoqaHanSansNeo-Regular.ttf') format('truetype');
-}
-
-@font-face {
-    font-family: 'Spoqa Han Sans Neo';
-    font-weight: 300;
-    font-display: swap;
-    src: local('Spoqa Han Sans Neo Light'),
-    url('../Subset/SpoqaHanSansNeo/SpoqaHanSansNeo-Light.woff2') format('woff2'),
-    url('../Subset/SpoqaHanSansNeo/SpoqaHanSansNeo-Light.woff') format('woff'),
-    url('../Subset/SpoqaHanSansNeo/SpoqaHanSansNeo-Light.ttf') format('truetype');
-}
-
-@font-face {
-    font-family: 'Spoqa Han Sans Neo';
-    font-weight: 100;
-    font-display: swap;
-    src: local('Spoqa Han Sans Neo Thin'),
-    url('../Subset/SpoqaHanSansNeo/SpoqaHanSansNeo-Thin.woff2') format('woff2'),
-    url('../Subset/SpoqaHanSansNeo/SpoqaHanSansNeo-Thin.woff') format('woff'),
-    url('../Subset/SpoqaHanSansNeo/SpoqaHanSansNeo-Thin.ttf') format('truetype');
+    url('../Subset/SpoqaHanSans/SpoqaHanSansThin.woff2') format('woff2'),
+    url('../Subset/SpoqaHanSans/SpoqaHanSansThin.woff') format('woff'),
+    url('../Subset/SpoqaHanSans/SpoqaHanSansThin.ttf') format('truetype');
 }


### PR DESCRIPTION
스포카 한 산스 네오에 미디엄 추가 정도의 변동만 있어서 `SpoqaHanSans-kr.css`도 변경해도 괜찮은줄 알았는데 다시 확인해보니 그렇지 않다고  합니다.

그래서 `SpoqaHanSans-kr.css`쪽은 예전 버전으로 서빙하도록 했습니다.

@KimWooHyun @YuuRiLee @baeharam 리뷰 부탁드립니다.

