### PR TITLE
static 주소에 `/` 두번 들어가는 현상 수정

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,18 +8,18 @@
     <meta property="og:type" content="website">
     <meta property="og:title" content="Spoqa Han Sans Neo">
     <meta property="og:description" content="Spoqa unveil the new Spoqa Han Sans Neo, which has evolved in many ways. | 여러모로 개선을 거쳐 진화한 스포카 한 산스 네오를 공개합니다. | これまでいろいろ改善して進化した新しいスポカーハンサンスネオを公開します。">
-    <meta property="og:image" content="{{ site.url }}/images/preview.png">
+    <meta property="og:image" content="{{ site.url }}images/preview.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@spoqa">
     <meta name="twitter:title" content="Spoqa Han Sans Neo">
     <meta name="twitter:description" content="Spoqa unveil the new Spoqa Han Sans Neo, which has evolved in many ways. | 여러모로 개선을 거쳐 진화한 스포카 한 산스 네오를 공개합니다. | これまでいろいろ改善して進化した新しいスポカーハンサンスネオを公開します。">
-    <meta name="twtiter:image" content="{{ site.url }}/images/preview.png">
+    <meta name="twtiter:image" content="{{ site.url }}images/preview.png">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-    <link rel="shortcut icon" href="{{ site.url }}/images/favicon.ico">
-    <link rel="stylesheet" type="text/css" href="{{ site.url }}/css/style.css">
+    <link rel="shortcut icon" href="{{ site.url }}images/favicon.ico">
+    <link rel="stylesheet" type="text/css" href="{{ site.url }}css/style.css">
     <link href='//fonts.googleapis.com/css?family=Source+Code+Pro' rel='stylesheet' type='text/css'>
-    <link href='{{ site.url }}/css/SpoqaHanSansNeo.css' rel='stylesheet' type='text/css'>
-    <link href='{{ site.url }}/css/SpoqaHanSans-jp.css' rel='stylesheet' type='text/css'>
+    <link href='{{ site.url }}css/SpoqaHanSansNeo.css' rel='stylesheet' type='text/css'>
+    <link href='{{ site.url }}css/SpoqaHanSans-jp.css' rel='stylesheet' type='text/css'>
     <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
     <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
     <script>
@@ -53,7 +53,7 @@
           document.documentElement.className += " no-touch";
       }
     </script>
-    <script type="text/javascript" src="{{ site.url }}/js/subnav-scrolling.js"></script>
+    <script type="text/javascript" src="{{ site.url }}js/subnav-scrolling.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/jquery-scrollTo/2.1.2/jquery.scrollTo.min.js"></script>
     <script type="text/javascript">
       $(window).load(function(){


### PR DESCRIPTION
https://github.com/spoqa/spoqa-han-sans/blob/gh-pages/_config.yml
`{{ site.url }}` 에 이미 끝에 trailing slash 가 들어가서 사용하는곳에서 제거해줍니다.

![image](https://user-images.githubusercontent.com/4816936/101332128-3c324f00-38b8-11eb-8ee5-401677ae3c89.png)
