### PR TITLE
[VD-4998] 영문 페이지 슬라이더 오작동 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.yml
 .DS_Store
+.jekyll-cache
+_site

--- a/en-US/index.html
+++ b/en-US/index.html
@@ -244,7 +244,7 @@ og_url: https://spoqa.github.io/spoqa-han-sans/en-US/
 <textarea></textarea>
 </div>
 
-    <script src="{{ stie.url }}/js/slider.js">
+    <script src="{{ site.url }}/js/slider.js">
     </script>
     </div>
   </section>


### PR DESCRIPTION
#171 에서 리포트 된 영문 페이지의 슬라이더 오작동 문제를 해결합니다.
+ 더불어서 `jekyll-serve` 로 로컬에서 사이트 생성했을 때 git이 못 잡도록 업데이트 합니다. (사소해서 여기 반영합니다)